### PR TITLE
Added meta tag to enable static websites to embed scripts from remote

### DIFF
--- a/app/chat_user/templates/user_chat/embed.js
+++ b/app/chat_user/templates/user_chat/embed.js
@@ -9,7 +9,9 @@
   var container = document.createElement("div");
   container.id = "embedded-chat-widget";
   document.body.appendChild(container);
-
+  document.getElementsByTagName('head')[0].innerHTML += 
+  '<meta http-equiv="Content-Security-Policy" content="default-src gap://ready file://* *; style-src \'self\' http://* https://* \'unsafe-inline\'; script-src \'self\' http://* https://* \'unsafe-inline\' \'unsafe-eval\'; connect-src \'self\' https://*.static.domains https://static.app https://www.chatbot.digitranslab.com;">';
+  
   var cssFiles = [
     "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.1.3/css/bootstrap.min.css",
     "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css",


### PR DESCRIPTION
Due to error given on test website 
Content-Security-Policy: The page’s settings blocked the loading of a resource (connect-src) at https://www.chatbot.digitranslab.com/chat_user/widget because it violates the following directive: “connect-src 'self' https://*.static.domains https://static.app”
